### PR TITLE
adding css to fix overflow text in input

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,6 +34,8 @@ body {
   box-shadow: 6px 6px 16px 0 var(--dark-high-light), -6px -6px 16px 0 var(--soft-high-light), inset 6px 6px 5px 0 var(--dark-high-light), inset -6px -6px 5px 0 var(--soft-high-light);
   border: 5px solid var(--soft-high-light);
   color: var(--secondary-font-color);
+  overflow: hidden;
+  direction: rtl;
 }
 
 .neumorphic {
@@ -49,7 +51,7 @@ body {
 }
 
 /*
-  GRID LAYOUT & NON NEUMORPHIC 
+  GRID LAYOUT & NON NEUMORPHIC
 */
 body {
   display: grid;
@@ -300,7 +302,7 @@ body {
 }
 
 /*
-  GRID LAYOUT & NON NEUMORPHIC 
+  GRID LAYOUT & NON NEUMORPHIC
 */
 body {
   display: grid;


### PR DESCRIPTION
So, when you start typing the number in the input box the box size increases and when it reaches to its max the text starts flowing outside of the box on the right.
Have made a fix to stop overflow of text and make it flow on left as a normal calculator.